### PR TITLE
Standard backend status reporting

### DIFF
--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -157,6 +157,7 @@ function instrumental_status(writeCb) {
   for (stat in instrumentalStats) {
     writeCb(null, 'instrumental', stat, instrumentalStats[stat]);
   }
+  writeCb(null, 'instrumental', 'error', error ? 1 : 0);
 }
 
 exports.init = function instrumental_init(startup_time, config, events) {


### PR DESCRIPTION
Adds last_flush and last_exception output to the stats command. These match the stats reported by other backends which display the delta since the last event, or the statsd instance was started.

I find the delta reporting a bit confusing, so I also added error which shows 0 when things are going well, 1 if an error was encountered in the last flush. This is in a separate commit if you'd like to omit it.

```
$ echo stats | nc localhost 8126
uptime: 2
messages.last_msg_seen: 2
messages.bad_lines_seen: 0
instrumental.last_flush: 2
instrumental.last_exception: 2
instrumental.error: 0
```
