### PR TITLE
Metric prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.11.3 [December 8th, 2016]
+* Add metricPrefix option, which will be added to all of your metrics (with a "." to seperate them)
+
 ### 0.11.2 [March 28th, 2016]
 * Add recordCounterRates option for users who wish to ignore .rate metrics on counters
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ### 0.11.3 [December 8th, 2016]
-* Add metricPrefix option, which will be added to all of your metrics (with a "." to seperate them)
+* Add `metricPrefix` option, which will be added to all of your metrics (with a "." to seperate them)
 
 ### 0.11.2 [March 28th, 2016]
 * Add recordCounterRates option for users who wish to ignore .rate metrics on counters

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ StatsD config file.
     secure: true,                 // OPTIONAL (boolean), whether or not to use secure protocol to connect to Instrumental, default true
     verifyCert: true,             // OPTIONAL (boolean), should we attempt to verify the server certificate before allowing communication, default true
     timeout: 10000,               // OPTIONAL (integer), number of milliseconds to wait for establishing a connection to Instrumental before giving up, default 10s
-    recordCounterRates: true      // OPTIONAL (boolean) whether or not to send ".rate" metrics with counters, default true
+    recordCounterRates: false     // OPTIONAL (boolean) whether or not to send ".rate" metrics with counters, default true
+    metricPrefix: ""              // OPTIONAL (string) this will be prepended (with a dot) to ALL of your metrics
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ StatsD config file.
     secure: true,                 // OPTIONAL (boolean), whether or not to use secure protocol to connect to Instrumental, default true
     verifyCert: true,             // OPTIONAL (boolean), should we attempt to verify the server certificate before allowing communication, default true
     timeout: 10000,               // OPTIONAL (integer), number of milliseconds to wait for establishing a connection to Instrumental before giving up, default 10s
-    recordCounterRates: true     // OPTIONAL (boolean) whether or not to send ".rate" metrics with counters, default true
+    recordCounterRates: true,     // OPTIONAL (boolean) whether or not to send ".rate" metrics with counters, default true
     metricPrefix: ""              // OPTIONAL (string) this will be prepended (with a dot) to ALL of your metrics
   }
 }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ StatsD config file.
     secure: true,                 // OPTIONAL (boolean), whether or not to use secure protocol to connect to Instrumental, default true
     verifyCert: true,             // OPTIONAL (boolean), should we attempt to verify the server certificate before allowing communication, default true
     timeout: 10000,               // OPTIONAL (integer), number of milliseconds to wait for establishing a connection to Instrumental before giving up, default 10s
-    recordCounterRates: false     // OPTIONAL (boolean) whether or not to send ".rate" metrics with counters, default true
+    recordCounterRates: true     // OPTIONAL (boolean) whether or not to send ".rate" metrics with counters, default true
     metricPrefix: ""              // OPTIONAL (string) this will be prepended (with a dot) to ALL of your metrics
   }
 }

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -12,5 +12,6 @@ exports.config = {
     verifyCert: true, // OPTIONAL (boolean), should we attempt to verify the server certificate before allowing communication, default true
     timeout: 10000, // OPTIONAL (integer), number of milliseconds to wait for establishing a connection to Instrumental before giving up, default 10s
     recordCounterRates: true, // OPTIONAL (boolean) whether or not to send ".rate" metrics with counters, default true
+    metricPrefix: "", // OPTIONAL (string) this will be prepended (with a dot) to ALL of your metrics
   }
 }

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -37,6 +37,7 @@ var caChainPath = path.join("..", "certs");
 var knownCerts  = ["equifax", "geotrust", "rapidssl"];
 var exports = module.exports = {}; // for testing
 var key, host, port, timeout, flushInterval, secure, verifyCert, caChain, recordCounterRates, metricPrefix;
+var format_metric_name = function(metric){ return metric; }
 
 var instrumentalStats = {};
 
@@ -99,19 +100,6 @@ function build_payload(metrics, time_stamp) {
   return payload;
 }
 exports.build_payload = build_payload;
-
-function format_metric_name(metric){
-  if(metricPrefix !== "" && metricPrefix !== ".") {
-    if(metricPrefix.endsWith("."))
-    {
-      return [metricPrefix, metric].join("");
-    } else {
-      return [metricPrefix, metric].join(".");
-    }
-  }
-  return metric;
-}
-
 
 function instrumental_connection(host, port, onConnectCb){
   var connection;
@@ -245,9 +233,19 @@ exports.init = function instrumental_init(startup_time, config, events) {
       recordCounterRates = config.instrumental.recordCounterRates;
     }
 
-    if(typeof(config.instrumental.metricPrefix) === 'undefined'){
-      metricPrefix = "";
-    } else {
+    if(typeof(config.instrumental.metricPrefix) !== 'undefined' &&
+       config.instrumental.metricPrefix != "" &&
+       config.instrumental.metricPrefix != "."){
+      var joinCharacter = ".";
+
+      if(config.instrumental.metricPrefix.endsWith("."))
+      {
+        joinCharacter = "";
+      }
+
+      format_metric_name = function(metric) {
+        return [config.instrumental.metricPrefix, metric].join(joinCharacter);
+      }
       metricPrefix = config.instrumental.metricPrefix;
     }
 

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -43,11 +43,11 @@ var instrumentalStats = {};
 function build_payload(metrics, time_stamp) {
   var payload = [];
   // Iterators: key and value.
-  var k, v;
+  var k, v, name, vps;
 
   // increment item.count 200 121820381
   for(k in metrics.counters) {
-    var name = format_metric_name(k);
+    name = format_metric_name(k);
     v = metrics.counters[k];
 
     // Skip any counters that would not change the value
@@ -56,14 +56,14 @@ function build_payload(metrics, time_stamp) {
     }
 
     if(recordCounterRates) {
-      var vps = metrics.counter_rates[k];
+      vps = metrics.counter_rates[k];
       payload.push(p.gauge_abs([name, "rate"].join("."), vps, time_stamp));
     }
   }
 
   // gauge item.time 7292 121820381
   for(k in metrics.timer_data){
-    var name = format_metric_name(k);
+    name = format_metric_name(k);
     for (var timer_data_key in metrics.timer_data[k]) {
       if (typeof(metrics.timer_data[k][timer_data_key]) === 'number') {
         payload.push(p.gauge_abs([k, timer_data_key].join("."), metrics.timer_data[k][timer_data_key], time_stamp));
@@ -84,12 +84,12 @@ function build_payload(metrics, time_stamp) {
 
   // gauge item.gauge 7292 121820381
   for(k in metrics.gauges) {
-    var name = format_metric_name(k);
+    name = format_metric_name(k);
     payload.push(p.gauge(name, metrics.gauges[k], time_stamp));
   }
 
   for(k in metrics.sets) {
-    var name = format_metric_name(k);
+    name = format_metric_name(k);
     payload.push(p.gauge_abs(name, metrics.sets[k].values().length, time_stamp));
   }
 
@@ -101,8 +101,13 @@ function build_payload(metrics, time_stamp) {
 exports.build_payload = build_payload;
 
 function format_metric_name(metric){
-  if(metricPrefix != "" && metricPrefix != ".") {
-    return [metricPrefix, metric].join(".");
+  if(metricPrefix !== "" && metricPrefix !== ".") {
+    if(metricPrefix.endsWith("."))
+    {
+      return [metricPrefix, metric].join("");
+    } else {
+      return [metricPrefix, metric].join(".");
+    }
   }
   return metric;
 }

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -36,7 +36,7 @@ var hostname = os.hostname();
 var caChainPath = path.join("..", "certs");
 var knownCerts  = ["equifax", "geotrust", "rapidssl"];
 var exports = module.exports = {}; // for testing
-var key, host, port, timeout, flushInterval, secure, verifyCert, caChain, recordCounterRates;
+var key, host, port, timeout, flushInterval, secure, verifyCert, caChain, recordCounterRates, metricPrefix;
 
 var instrumentalStats = {};
 
@@ -47,21 +47,23 @@ function build_payload(metrics, time_stamp) {
 
   // increment item.count 200 121820381
   for(k in metrics.counters) {
+    var name = format_metric_name(k);
     v = metrics.counters[k];
 
     // Skip any counters that would not change the value
     if(v !== 0) {
-      payload.push(p.inc(k, v, time_stamp));
+      payload.push(p.inc(name, v, time_stamp));
     }
 
     if(recordCounterRates) {
       var vps = metrics.counter_rates[k];
-      payload.push(p.gauge_abs([k, "rate"].join("."), vps, time_stamp));
+      payload.push(p.gauge_abs([name, "rate"].join("."), vps, time_stamp));
     }
   }
 
   // gauge item.time 7292 121820381
   for(k in metrics.timer_data){
+    var name = format_metric_name(k);
     for (var timer_data_key in metrics.timer_data[k]) {
       if (typeof(metrics.timer_data[k][timer_data_key]) === 'number') {
         payload.push(p.gauge_abs([k, timer_data_key].join("."), metrics.timer_data[k][timer_data_key], time_stamp));
@@ -82,11 +84,13 @@ function build_payload(metrics, time_stamp) {
 
   // gauge item.gauge 7292 121820381
   for(k in metrics.gauges) {
-    payload.push(p.gauge(k, metrics.gauges[k], time_stamp));
+    var name = format_metric_name(k);
+    payload.push(p.gauge(name, metrics.gauges[k], time_stamp));
   }
 
   for(k in metrics.sets) {
-    payload.push(p.gauge_abs(k, metrics.sets[k].values().length, time_stamp));
+    var name = format_metric_name(k);
+    payload.push(p.gauge_abs(name, metrics.sets[k].values().length, time_stamp));
   }
 
   // By this point in time we should have an array of commands to send to the
@@ -95,6 +99,13 @@ function build_payload(metrics, time_stamp) {
   return payload;
 }
 exports.build_payload = build_payload;
+
+function format_metric_name(metric){
+  if(metricPrefix != "" && metricPrefix != ".") {
+    return [metricPrefix, metric].join(".");
+  }
+  return metric;
+}
 
 
 function instrumental_connection(host, port, onConnectCb){
@@ -227,6 +238,12 @@ exports.init = function instrumental_init(startup_time, config, events) {
       recordCounterRates = true;
     } else {
       recordCounterRates = config.instrumental.recordCounterRates;
+    }
+
+    if(typeof(config.instrumental.metricPrefix) == 'undefined'){
+      metricPrefix = "";
+    } else {
+      metricPrefix = config.instrumental.metricPrefix;
     }
 
     if(typeof(config.instrumental.secure) == 'undefined'){

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -239,27 +239,27 @@ exports.init = function instrumental_init(startup_time, config, events) {
     timeout = Number(config.instrumental.timeout || 10000);
 
     // Record counter_rates by default
-    if(typeof(config.instrumental.recordCounterRates) == 'undefined'){
+    if(typeof(config.instrumental.recordCounterRates) === 'undefined'){
       recordCounterRates = true;
     } else {
       recordCounterRates = config.instrumental.recordCounterRates;
     }
 
-    if(typeof(config.instrumental.metricPrefix) == 'undefined'){
+    if(typeof(config.instrumental.metricPrefix) === 'undefined'){
       metricPrefix = "";
     } else {
       metricPrefix = config.instrumental.metricPrefix;
     }
 
-    if(typeof(config.instrumental.secure) == 'undefined'){
+    if(typeof(config.instrumental.secure) === 'undefined'){
       secure = true;
     } else {
       secure = config.instrumental.secure;
     }
 
     // necessary while we transition config from verify_cert to verifyCert.
-    if(typeof(config.instrumental.verifyCert) == 'undefined'){
-      if(typeof(config.instrumental.verify_cert) == 'undefined'){
+    if(typeof(config.instrumental.verifyCert) === 'undefined'){
+      if(typeof(config.instrumental.verify_cert) === 'undefined'){
         verifyCert = true;
       } else {
         verifyCert = config.instrumental.verify_cert;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Chris Gaffney <chris@collectiveidea.com>",
   "name": "statsd-instrumental-backend",
   "description": "A StatsD backend for Instrumental",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "homepage": "https://github.com/expectedbehavior/statsd-instrumental-backend",
   "repository": {
     "type": "git",

--- a/test/instrumental_test.js
+++ b/test/instrumental_test.js
@@ -35,3 +35,21 @@ test('counter_rate should not report if disabled in configuration', function (t)
 
   t.end();
 });
+
+test('metricPrefix is used if present in configuration', function (t) {
+  var metrics = {
+    counters: { 'my.test.1': 2805 }
+  };
+
+  var now = Math.round(new Date().getTime() / 1000);
+  var dummy_events =  { on: function(e){ } };
+
+  config.instrumental.metricPrefix = "testprefix";
+  instrumental.init(now, config, dummy_events)
+
+  var payload = instrumental.build_payload(metrics);
+
+   t.assert(payload.indexOf("increment testprefix.my.test.1 2805 ") > -1, "Metric name was not prefixed properly (got " + JSON.stringify(payload) + ")")
+
+  t.end();
+});

--- a/test/instrumental_test.js
+++ b/test/instrumental_test.js
@@ -53,3 +53,21 @@ test('metricPrefix is used if present in configuration', function (t) {
 
   t.end();
 });
+
+test('metricPrefix ending with dots wont send double dots', function (t) {
+  var metrics = {
+    counters: { 'my.test.1': 2805 }
+  };
+
+  var now = Math.round(new Date().getTime() / 1000);
+  var dummy_events =  { on: function(e){ } };
+
+  config.instrumental.metricPrefix = "testprefix.";
+  instrumental.init(now, config, dummy_events)
+
+  var payload = instrumental.build_payload(metrics);
+
+   t.assert(payload.indexOf("increment testprefix.my.test.1 2805 ") > -1, "Metric name was not prefixed properly (got " + JSON.stringify(payload) + ")")
+
+  t.end();
+});


### PR DESCRIPTION
Add "metricPrefix" option.  If set, all metrics sent to instrumental will have its value, and then a dot, prepended to the name of the metric.

So, if metricPrefix is set to `statsd`, `server-101.memory.percent_used` becomes `statsd.server-101.memory.percent_used` in Instrumental.