### PR TITLE
regex.test is not available in some javascript environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.12.4 [March 23rd, 2017]
+* Revert to string.match from regex.test.  String.match is available in more environments.
+
 ### 0.12.3 [March 21st, 2017]
 * Remove some logging that snuck in to production
 

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -252,8 +252,8 @@ exports.init = function instrumental_init(startup_time, config, events) {
     }
     keepMetric = function(metric){
       metricName = metric.split(" ")[1];
-      return (!metricFiltersExclude.some(function(filter) { return filter.test(metricName); }) &&
-              (metricFiltersInclude.length == 0 || metricFiltersInclude.some(function(filter) { return filter.test(metricName); })));
+      return (!metricFiltersExclude.some(function(filter) { return metricName.match(filter); }) &&
+              (metricFiltersInclude.length == 0 || metricFiltersInclude.some(function(filter) { return metricName.match(filter); })));
     };
 
     if(typeof(config.instrumental.metricPrefix) !== 'undefined' &&

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Chris Gaffney <chris@collectiveidea.com>",
   "name": "statsd-instrumental-backend",
   "description": "A StatsD backend for Instrumental",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "homepage": "https://github.com/expectedbehavior/statsd-instrumental-backend",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Reverts to string.match, which SHOULD be available everywhere.