### PR TITLE
Only log connection info on init

### DIFF
--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -117,7 +117,6 @@ exports.build_payload = build_payload;
 
 function instrumental_connection(host, port, tlsOptionsVariation, onConnectCb){
   var connection;
-  log("Connecting to " + host + ":" + port)
   if (secure){
     if (debug) log("Using certs: " + tlsOptionsVariation.name);
     connection = tls.connect(port, host, tlsOptionsVariation.options, function(){
@@ -441,6 +440,8 @@ exports.init = function instrumental_init(startup_time, config, events) {
     log("Missing instrumental.key from the config.");
     return false;
   }
+
+  log("Connecting to " + host + ":" + port)
 
   instrumentalStats.last_flush = startup_time;
   instrumentalStats.last_exception = startup_time;

--- a/lib/instrumental.js
+++ b/lib/instrumental.js
@@ -278,6 +278,8 @@ function knownValidCertNames() {
     certExpiration = certExpiration && new Date(Date.parse(certExpiration));
     if ( ! certExpiration || (new Date() < certExpiration) ){
       certNames.push(certName);
+    } else {
+      if (debug) log("Ignoring expired cert bundle: " + certName);
     }
   });
   return certNames;

--- a/test/filtering_test.js
+++ b/test/filtering_test.js
@@ -4,10 +4,10 @@ var path = require("path");
 var util = require("util");
 var fs   = require("fs");
 
-test = TestHelper.test;
-setup = TestHelper.setup;
-sendMetric = TestHelper.sendMetric;
-checkForMetric = TestHelper.checkForMetric;
+var test = TestHelper.test;
+var setup = TestHelper.setup;
+var sendMetric = TestHelper.sendMetric;
+var checkForMetric = TestHelper.checkForMetric;
 
 test('no filtering is done if minimal config specified', function (t) {
   metrics = {

--- a/test/instrumental_test.js
+++ b/test/instrumental_test.js
@@ -1,102 +1,13 @@
-var tape_test = require('tape');
-var instrumental;
-var originalConfig = require("../exampleConfig.js").config;
-var https = require("https");
-var EventEmitter = require('events');
+var TestHelper = require("./test_helper");
 var timekeeper = require('timekeeper');
 var path = require("path");
 var util = require("util");
 var fs   = require("fs");
 
-var timedOut = false;
-var timer, config, log;
-
-var test = function(name, testFunction){
-  tape_test(name, function(t){
-    // Clear any state in the backend
-    delete require.cache[require.resolve('../lib/instrumental.js')]
-    instrumental = require("../lib/instrumental.js");
-
-    // Start with a fresh config based off the example with minor modifications
-    config = JSON.parse(JSON.stringify(originalConfig));
-    config.instrumental.key = process.env.INSTRUMENTAL_TEST_TOKEN;
-    config.instrumental.recordCounterRates = false;
-    config.instrumental.host = "collector.instrumentalapp.com";
-    config.debug = true; // allow log verification
-    config.instrumental.metricPrefix = "";
-    config.instrumental.log = function(){
-      // console.warn(util.format.apply(null, arguments));
-      log.push(util.format.apply(null, arguments));
-    };
-
-    // Setup state to check for timeouts polling the API
-    timedOut = false;
-    if (timer) clearTimeout(timer);
-
-    // Reset timekeeper so time behaves normally by default
-    timekeeper.reset();
-
-    // Collect log messages for checking in tests
-    log = [];
-
-    // Run the test
-    testFunction(t);
-  });
-};
-
-function sendMetric(metricName, time, options){
-  if(typeof(options) === 'undefined') options = {};
-  if (!options.skipInit) {
-    dummy_events = new EventEmitter();
-    instrumental.init(now, config, dummy_events)
-  };
-  metrics = {
-    counters: {},
-    counter_rates: {},
-    timer_data: {},
-    gauges: {},
-    sets: {},
-  };
-  metrics.counters[metricName] = 1;
-  dummy_events.emit("flush", time, metrics);
-}
-
-function checkForMetric(metricName, options) {
-  var httpOptions = {
-    hostname: 'instrumentalapp.com',
-    path: '/api/2/metrics/'+metricName,
-    headers: {
-      'X-Instrumental-Token': process.env.INSTRUMENTAL_TEST_TOKEN,
-    }
-  };
-  var req = https.get(httpOptions, function(res){
-    // console.warn('statusCode:', res.statusCode);
-    // console.warn('headers:', res.headers);
-    var body = '';
-    res.on('data', function(chunk) {
-      body += chunk;
-    });
-    res.on('end', function() {
-      // console.warn(body);
-      var data = JSON.parse(body).response.metrics[0].values.data;
-      var last_point = data[data.length-1];
-      var expectedSum = options.expectedSum || 1;
-      if (last_point.s == expectedSum) {
-        options.found();
-      } else {
-        if (timedOut) {
-          options.timeout();
-        } else {
-          setTimeout(function(){checkForMetric(metricName, options)}, 1000);
-        }
-      }
-    });
-  });
-  req.on('error', function(e){
-    console.error(e.message);
-    options.error();
-  });
-}
+test = TestHelper.test;
+setup = TestHelper.setup;
+sendMetric = TestHelper.sendMetric;
+checkForMetric = TestHelper.checkForMetric;
 
 test('counter_rate should not report if disabled in configuration', function (t) {
   metrics = {
@@ -106,20 +17,20 @@ test('counter_rate should not report if disabled in configuration', function (t)
 
   now = Math.round(new Date().getTime() / 1000);
   dummy_events =  { on: function(e){ } };
-  config.instrumental.recordCounterRates = true;
-  instrumental.init(now, config, dummy_events);
+  TestHelper.config.instrumental.recordCounterRates = true;
+  TestHelper.instrumental.init(now, TestHelper.config, dummy_events);
 
   // Enable rate counters and ensure they are recorded
-  payload = instrumental.build_payload(metrics);
+  payload = TestHelper.instrumental.build_payload(metrics);
 
   // TODO: What's with the fucking space on the end of this string?
    t.assert(payload.indexOf("gauge_absolute my.test.1.rate 280.5 ") > -1, "Expected a rate metric, got: " + JSON.stringify(payload))
 
   // Disable rate counters and ensure they are NOT recorded
-  config.instrumental.recordCounterRates = false;
-  instrumental.init(now, config, dummy_events);
+  TestHelper.config.instrumental.recordCounterRates = false;
+  TestHelper.instrumental.init(now, TestHelper.config, dummy_events);
 
-  payload = instrumental.build_payload(metrics);
+  payload = TestHelper.instrumental.build_payload(metrics);
   payload.forEach(function(instrumental_metric) {
     if (instrumental_metric.indexOf("rate") > -1) {
       t.fail("Should not be any rate metrics: " + instrumental_metric);
@@ -139,10 +50,10 @@ test('metricPrefix is used if present in configuration', function (t) {
   now = Math.round(new Date().getTime() / 1000);
   dummy_events =  { on: function(e){ } };
 
-  config.instrumental.metricPrefix = "testprefix";
-  instrumental.init(now, config, dummy_events);
+  TestHelper.config.instrumental.metricPrefix = "testprefix";
+  TestHelper.instrumental.init(now, TestHelper.config, dummy_events);
 
-  payload = instrumental.build_payload(metrics);
+  payload = TestHelper.instrumental.build_payload(metrics);
 
   t.assert(payload.indexOf("increment testprefix.my.test.1 2805 ") > -1, "Metric name was not prefixed properly (got " + JSON.stringify(payload) + ")");
 
@@ -157,10 +68,10 @@ test('metricPrefix ending with dots wont send double dots', function (t) {
   now = Math.round(new Date().getTime() / 1000);
   dummy_events =  { on: function(e){ } };
 
-  config.instrumental.metricPrefix = "testprefix.";
-  instrumental.init(now, config, dummy_events);
+  TestHelper.config.instrumental.metricPrefix = "testprefix.";
+  TestHelper.instrumental.init(now, TestHelper.config, dummy_events);
 
-  payload = instrumental.build_payload(metrics);
+  payload = TestHelper.instrumental.build_payload(metrics);
 
   t.assert(payload.indexOf("increment testprefix.my.test.1 2805 ") > -1, "Metric name was not prefixed properly (got " + JSON.stringify(payload) + ")");
 
@@ -171,7 +82,7 @@ test("by default no messages are logged on every meetric send", function (t) {
   oldTime = Math.round(new Date().getTime() / 1000);
 
   // the default config value in production, though the default in test is true
-  config.debug = false;
+  TestHelper.config.debug = false;
 
   var metricName = "test.metric"+Math.random();
   sendMetric(metricName, oldTime);
@@ -185,7 +96,7 @@ test("by default no messages are logged on every meetric send", function (t) {
     expectedSum: 6, // failures don't get sent
     found: function(){
       var cert_log_messages =
-        log.filter(function(entry){return true});
+        TestHelper.log.filter(function(entry){return true});
       var expected_messages = [
         "Adding node default ssl cert option",
         "Found valid cert bundle: digicert_intermediate",
@@ -201,7 +112,7 @@ test("by default no messages are logged on every meetric send", function (t) {
     },
     timeout: function(){
       var cert_log_messages =
-        log.filter(function(entry){return true});
+        TestHelper.log.filter(function(entry){return true});
       t.fail(JSON.stringify(cert_log_messages) + "\n\n");
       t.end();
     },

--- a/test/instrumental_test.js
+++ b/test/instrumental_test.js
@@ -4,10 +4,10 @@ var path = require("path");
 var util = require("util");
 var fs   = require("fs");
 
-test = TestHelper.test;
-setup = TestHelper.setup;
-sendMetric = TestHelper.sendMetric;
-checkForMetric = TestHelper.checkForMetric;
+var test = TestHelper.test;
+var setup = TestHelper.setup;
+var sendMetric = TestHelper.sendMetric;
+var checkForMetric = TestHelper.checkForMetric;
 
 test('counter_rate should not report if disabled in configuration', function (t) {
   metrics = {

--- a/test/instrumental_test.js
+++ b/test/instrumental_test.js
@@ -78,7 +78,7 @@ test('metricPrefix ending with dots wont send double dots', function (t) {
   t.end();
 });
 
-test("by default no messages are logged on every meetric send", function (t) {
+test("with default production debug confirguation no messages are logged on every metric send", function (t) {
   oldTime = Math.round(new Date().getTime() / 1000);
 
   // the default config value in production, though the default in test is true

--- a/test/instrumental_test.js
+++ b/test/instrumental_test.js
@@ -22,7 +22,7 @@ var test = function(name, testFunction){
     config.instrumental.key = process.env.INSTRUMENTAL_TEST_TOKEN;
     config.instrumental.recordCounterRates = false;
     config.instrumental.host = "collector.instrumentalapp.com";
-    config.instrumental.debug = true; // allow log verification
+    config.debug = true; // allow log verification
     config.instrumental.metricPrefix = "";
     config.instrumental.log = function(){
       // console.warn(util.format.apply(null, arguments));

--- a/test/ssl_test.js
+++ b/test/ssl_test.js
@@ -4,10 +4,10 @@ var path = require("path");
 var util = require("util");
 var fs   = require("fs");
 
-test = TestHelper.test;
-setup = TestHelper.setup;
-sendMetric = TestHelper.sendMetric;
-checkForMetric = TestHelper.checkForMetric;
+var test = TestHelper.test;
+var setup = TestHelper.setup;
+var sendMetric = TestHelper.sendMetric;
+var checkForMetric = TestHelper.checkForMetric;
 
 test('specifying a valid and working cert bundle works', function(t) {
   setup(t);

--- a/test/ssl_test.js
+++ b/test/ssl_test.js
@@ -126,7 +126,7 @@ test('before cert expiration, fallback to newest cert bundle and stick if node d
 
   TestHelper.config.instrumental.tlsVariationTimeout = 500;
 
-  var timeBetweenSends = 1000;
+  var timeBetweenSends = 2000;
   var actions = [];
 
   // node default certs
@@ -229,7 +229,7 @@ test('after cert expiration, fallback to newest cert bundle and stick if node de
 
   TestHelper.config.instrumental.tlsVariationTimeout = 500;
 
-  var timeBetweenSends = 1000;
+  var timeBetweenSends = 2000;
   var actions = [];
 
   // node default certs

--- a/test/ssl_test.js
+++ b/test/ssl_test.js
@@ -1,117 +1,13 @@
-var tape_test = require('tape');
-var instrumental;
-var originalConfig = require("../exampleConfig.js").config;
-var https = require("https");
-var EventEmitter = require('events').EventEmitter;
+var TestHelper = require("./test_helper");
 var timekeeper = require('timekeeper');
 var path = require("path");
 var util = require("util");
 var fs   = require("fs");
 
-var timedOut = false;
-var timer, config, log;
-
-var test = function(name, testFunction){
-  tape_test(name, function(t){
-    // Clear any state in the backend
-    delete require.cache[require.resolve('../lib/instrumental.js')]
-    instrumental = require("../lib/instrumental.js");
-
-    // Start with a fresh config based off the example with minor modifications
-    config = JSON.parse(JSON.stringify(originalConfig));
-    config.instrumental.key = process.env.INSTRUMENTAL_TEST_TOKEN;
-    config.instrumental.recordCounterRates = false;
-    config.instrumental.host = "collector.instrumentalapp.com";
-    config.debug = true; // allow log verification
-    config.instrumental.metricPrefix = "";
-    config.instrumental.log = function(){
-      // console.warn(util.format.apply(null, arguments));
-      log.push(util.format.apply(null, arguments));
-    };
-
-    // Setup state to check for timeouts polling the API
-    timedOut = false;
-    if (timer) clearTimeout(timer);
-
-    // Reset timekeeper so time behaves normally by default
-    timekeeper.reset();
-
-    // Collect log messages for checking in tests
-    log = [];
-
-    // Run the test
-    testFunction(t);
-  });
-};
-
-var instrumentalLatency = 20000;
-
-function setup(t){
-  t.timeoutAfter(instrumentalLatency*2.2); // needs to be more than Instrumental latency, a little more than the timeout below
-
-  // Setup something to stop the checkForMetric loop so node exits.
-  timer = setTimeout(function(){
-    timedOut = true;
-  }, instrumentalLatency*2);
-  tape_test.onFinish(function(){
-    clearTimeout(timer);
-  });
-}
-
-function sendMetric(metricName, time, options){
-  if(typeof(options) === 'undefined') options = {};
-  if (!options.skipInit) {
-    dummy_events = new EventEmitter();
-    instrumental.init(now, config, dummy_events)
-  };
-  metrics = {
-    counters: {},
-    counter_rates: {},
-    timer_data: {},
-    gauges: {},
-    sets: {},
-  };
-  metrics.counters[metricName] = 1;
-  dummy_events.emit("flush", time, metrics);
-}
-
-function checkForMetric(metricName, options) {
-  var httpOptions = {
-    hostname: 'instrumentalapp.com',
-    path: '/api/2/metrics/'+metricName,
-    headers: {
-      'X-Instrumental-Token': process.env.INSTRUMENTAL_TEST_TOKEN,
-    }
-  };
-  var req = https.get(httpOptions, function(res){
-    // console.warn('statusCode:', res.statusCode);
-    // console.warn('headers:', res.headers);
-    var body = '';
-    res.on('data', function(chunk) {
-      body += chunk;
-    });
-    res.on('end', function() {
-      // console.warn(body);
-      var data = JSON.parse(body).response.metrics[0].values.data;
-      var last_point = data[data.length-1];
-      var expectedSum = options.expectedSum || 1;
-      if (last_point.s == expectedSum) {
-        options.found();
-      } else {
-        if (timedOut) {
-          options.timeout();
-        } else {
-          setTimeout(function(){checkForMetric(metricName, options)}, 1000);
-        }
-      }
-    });
-  });
-  req.on('error', function(e){
-    console.error(e.message);
-    options.error();
-  });
-}
-
+test = TestHelper.test;
+setup = TestHelper.setup;
+sendMetric = TestHelper.sendMetric;
+checkForMetric = TestHelper.checkForMetric;
 
 test('specifying a valid and working cert bundle works', function(t) {
   setup(t);
@@ -126,8 +22,8 @@ test('specifying a valid and working cert bundle works', function(t) {
     }
   });
 
-  config.instrumental.host = "smoke-collector.instrumentalapp.com";
-  config.instrumental.caCertFiles = certs;
+  TestHelper.config.instrumental.host = "smoke-collector.instrumentalapp.com";
+  TestHelper.config.instrumental.caCertFiles = certs;
   now = Math.round(new Date().getTime() / 1000);
   var metricName = "test.metric"+Math.random();
   sendMetric(metricName, oldTime);
@@ -161,15 +57,15 @@ test('specifying a valid but not working cert bundle retries', function(t) {
     }
   });
 
-  config.instrumental.host = "smoke-collector.instrumentalapp.com";
-  config.instrumental.caCertFiles = certs;
+  TestHelper.config.instrumental.host = "smoke-collector.instrumentalapp.com";
+  TestHelper.config.instrumental.caCertFiles = certs;
   now = Math.round(new Date().getTime() / 1000);
   var metricName = "test.metric"+Math.random();
   sendMetric(metricName, oldTime);
   sendMetric(metricName, oldTime, {skipInit: true});
   var checkConnectionErrors = function() {
     var connection_errors =
-      log.filter(function(entry){return entry.match(/Client error:/)});
+      TestHelper.log.filter(function(entry){return entry.match(/Client error:/)});
     t.equal(connection_errors.length, 2, "expected 2 connection attemps, 1 retry");
     t.end();
   };
@@ -181,8 +77,8 @@ test('specifying an invalid cert bundle errors', function(t) {
 
   oldTime = Math.round(new Date().getTime() / 1000);
 
-  config.instrumental.host = "smoke-collector.instrumentalapp.com";
-  config.instrumental.caCertFiles = ["non_existent_file"];
+  TestHelper.config.instrumental.host = "smoke-collector.instrumentalapp.com";
+  TestHelper.config.instrumental.caCertFiles = ["non_existent_file"];
   var metricName = "test.metric"+Math.random();
   t.throws(function(){
     sendMetric(metricName, oldTime);
@@ -195,14 +91,14 @@ test('node default certs are used by default', function(t) {
 
   oldTime = Math.round(new Date().getTime() / 1000);
 
-  config.instrumental.host = "smoke-collector.instrumentalapp.com";
+  TestHelper.config.instrumental.host = "smoke-collector.instrumentalapp.com";
   var metricName = "test.metric"+Math.random();
   sendMetric(metricName, oldTime);
 
   checkForMetric(metricName, {
     found: function(){
       var cert_log_messages =
-        log.filter(function(entry){return entry.match(/Using certs/i)});
+        TestHelper.log.filter(function(entry){return entry.match(/Using certs/i)});
       t.deepEqual(cert_log_messages, ["Using certs: node default"], "expected to use node default certs");
       t.pass();
       t.end();
@@ -228,14 +124,14 @@ test('before cert expiration, fallback to newest cert bundle and stick if node d
 
   var metricName = "test.metric"+Math.random();
 
-  config.instrumental.tlsVariationTimeout = 500;
+  TestHelper.config.instrumental.tlsVariationTimeout = 500;
 
   var timeBetweenSends = 1000;
   var actions = [];
 
   // node default certs
   actions.push(function(){
-    config.instrumental.host = "smoke-collector.instrumentalapp.com";
+    TestHelper.config.instrumental.host = "smoke-collector.instrumentalapp.com";
     sendMetric(metricName, realCurrentTime); // using node default certs
   });
   actions.push(function(){
@@ -244,11 +140,11 @@ test('before cert expiration, fallback to newest cert bundle and stick if node d
 
   // New cert bundle
   actions.push(function(){
-    config.instrumental.port = 8000;
+    TestHelper.config.instrumental.port = 8000;
     sendMetric(metricName, realCurrentTime); // node default certs fail
   });
   actions.push(function(){
-    config.instrumental.port = 8001;
+    TestHelper.config.instrumental.port = 8001;
     sendMetric(metricName, realCurrentTime); // bundle
   });
   actions.push(function(){
@@ -257,11 +153,11 @@ test('before cert expiration, fallback to newest cert bundle and stick if node d
 
   // Back to node default
   actions.push(function(){
-    config.instrumental.port = 8000;
+    TestHelper.config.instrumental.port = 8000;
     sendMetric(metricName, realCurrentTime); // bundle fails
   });
   actions.push(function(){
-    config.instrumental.port = 8001;
+    TestHelper.config.instrumental.port = 8001;
     sendMetric(metricName, realCurrentTime); // node default
   });
   actions.push(function(){
@@ -276,7 +172,7 @@ test('before cert expiration, fallback to newest cert bundle and stick if node d
     expectedSum: 6, // failures don't get sent
     found: function(){
       var cert_log_messages =
-        log.filter(function(entry){return entry.match(/\bcert/i)});
+        TestHelper.log.filter(function(entry){return entry.match(/\bcert/i)});
       var expected_messages = [
         "Adding node default ssl cert option",
         'Found valid cert bundle: equifax.2018-08-19',
@@ -309,7 +205,7 @@ test('before cert expiration, fallback to newest cert bundle and stick if node d
     },
     timeout: function(){
       var cert_log_messages =
-        log.filter(function(entry){return entry.match(/Using certs/i)});
+        TestHelper.log.filter(function(entry){return entry.match(/Using certs/i)});
       t.fail(JSON.stringify(cert_log_messages) + "\n\n");
       t.end();
     },
@@ -331,14 +227,14 @@ test('after cert expiration, fallback to newest cert bundle and stick if node de
 
   var metricName = "test.metric"+Math.random();
 
-  config.instrumental.tlsVariationTimeout = 500;
+  TestHelper.config.instrumental.tlsVariationTimeout = 500;
 
   var timeBetweenSends = 1000;
   var actions = [];
 
   // node default certs
   actions.push(function(){
-    config.instrumental.host = "smoke-collector.instrumentalapp.com";
+    TestHelper.config.instrumental.host = "smoke-collector.instrumentalapp.com";
     sendMetric(metricName, realCurrentTime); // using node default certs
   });
   actions.push(function(){
@@ -347,11 +243,11 @@ test('after cert expiration, fallback to newest cert bundle and stick if node de
 
   // New cert bundle
   actions.push(function(){
-    config.instrumental.port = 8000;
+    TestHelper.config.instrumental.port = 8000;
     sendMetric(metricName, realCurrentTime); // node default certs fail
   });
   actions.push(function(){
-    config.instrumental.port = 8001;
+    TestHelper.config.instrumental.port = 8001;
     sendMetric(metricName, realCurrentTime); // bundle
   });
   actions.push(function(){
@@ -360,11 +256,11 @@ test('after cert expiration, fallback to newest cert bundle and stick if node de
 
   // Back to node default
   actions.push(function(){
-    config.instrumental.port = 8000;
+    TestHelper.config.instrumental.port = 8000;
     sendMetric(metricName, realCurrentTime); // bundle fails
   });
   actions.push(function(){
-    config.instrumental.port = 8001;
+    TestHelper.config.instrumental.port = 8001;
     sendMetric(metricName, realCurrentTime); // node default
   });
   actions.push(function(){
@@ -379,7 +275,7 @@ test('after cert expiration, fallback to newest cert bundle and stick if node de
     expectedSum: 6, // failures don't get sent
     found: function(){
       var cert_log_messages =
-        log.filter(function(entry){return entry.match(/\bcert/i)});
+        TestHelper.log.filter(function(entry){return entry.match(/\bcert/i)});
       var expected_messages = [
         "Adding node default ssl cert option",
         'Ignoring expired cert bundle: equifax.2018-08-19',
@@ -415,7 +311,7 @@ test('after cert expiration, fallback to newest cert bundle and stick if node de
     },
     timeout: function(){
       var cert_log_messages =
-        log.filter(function(entry){return entry.match(/Using certs/i)});
+        TestHelper.log.filter(function(entry){return entry.match(/Using certs/i)});
       t.fail(JSON.stringify(cert_log_messages) + "\n\n");
       t.end();
     },
@@ -434,7 +330,7 @@ test('old agent works with new elb', function(t) {
   var time = new Date(Date.parse("2019-01-01"));
   timekeeper.travel(time); // Travel to that date.
 
-  config.instrumental.host = "smoke-collector.instrumentalapp.com";
+  TestHelper.config.instrumental.host = "smoke-collector.instrumentalapp.com";
   var metricName = "test.metric"+Math.random();
   sendMetric(metricName, oldTime);
 
@@ -464,7 +360,7 @@ test('old agent works with new elb', function(t) {
 //   var time = new Date(Date.parse("2018-01-01"));
 //   timekeeper.travel(time); // Travel to that date.
 //
-//   config.instrumental.host = "collector.instrumentalapp.com";
+//   TestHelper.config.instrumental.host = "collector.instrumentalapp.com";
 //   now = Math.round(new Date().getTime() / 1000);
 //   var metricName = "test.metric"+Math.random();
 //   sendMetric(metricName, realCurrentTime);
@@ -495,20 +391,20 @@ test('old agent works with new elb', function(t) {
 //   var time = new Date(Date.parse("2019-01-01"));
 //   timekeeper.travel(time); // Travel to that date.
 //
-//   config.instrumental.disallowNodeDefaultCerts = true;
-//   config.instrumental.host = "old-elb.instrumentalapp.com";
+//   TestHelper.config.instrumental.disallowNodeDefaultCerts = true;
+//   TestHelper.config.instrumental.host = "old-elb.instrumentalapp.com";
 //   now = Math.round(new Date().getTime() / 1000);
 //   var metricName = "test.metric"+Math.random();
 //   sendMetric(metricName, oldTime);
 //
 //   checkForMetric(metricName, {
 //     found: function(){
-//       t.fail("Future agent shouldn't work with the old ELB, logs: " + log);
+//       t.fail("Future agent shouldn't work with the old ELB, logs: " + TestHelper.log);
 //       t.end();
 //     },
 //     timeout: function(){
 //       var cert_log_messages =
-//         log.filter(function(entry){
+//         TestHelper.log.filter(function(entry){
 //           return entry.match(/\bcert/i) &&
 //             !entry.match(/Error: unable to get/i) &&
 //             !entry.match(/Error: CERT_UNTRUSTED/i) &&
@@ -541,7 +437,7 @@ test('future agent correctly expires cert and works with new elb', function(t) {
   var time = new Date(Date.parse("2019-01-01"));
   timekeeper.travel(time); // Travel to that date.
 
-  config.instrumental.host = "smoke-collector.instrumentalapp.com";
+  TestHelper.config.instrumental.host = "smoke-collector.instrumentalapp.com";
   now = Math.round(new Date().getTime() / 1000);
   var metricName = "test.metric"+Math.random();
   sendMetric(metricName, oldTime);

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -1,0 +1,114 @@
+var tape_test = require('tape');
+var originalConfig = require("../exampleConfig.js").config;
+var https = require("https");
+var EventEmitter = require('events').EventEmitter;
+var timekeeper = require('timekeeper');
+var path = require("path");
+var util = require("util");
+var fs   = require("fs");
+
+var timedOut = false;
+var timer;
+
+exports.test = function(name, testFunction){
+  tape_test(name, function(t){
+    // Clear any state in the backend
+    delete require.cache[require.resolve('../lib/instrumental.js')]
+    exports.instrumental = require("../lib/instrumental.js");
+
+    // Start with a fresh config based off the example with minor modifications
+    config = JSON.parse(JSON.stringify(originalConfig));
+    config.instrumental.key = process.env.INSTRUMENTAL_TEST_TOKEN;
+    config.instrumental.recordCounterRates = false;
+    config.instrumental.host = "collector.instrumentalapp.com";
+    config.debug = true; // allow log verification
+    config.instrumental.metricPrefix = "";
+    config.instrumental.log = function(){
+      // console.warn(util.format.apply(null, arguments));
+      log.push(util.format.apply(null, arguments));
+    };
+    exports.config = config;
+
+    // Setup state to check for timeouts polling the API
+    timedOut = false;
+    if (timer) clearTimeout(timer);
+
+    // Reset timekeeper so time behaves normally by default
+    timekeeper.reset();
+
+    // Collect log messages for checking in tests
+    log = [];
+    exports.log = log;
+
+    // Run the test
+    testFunction(t);
+  });
+};
+
+var instrumentalLatency = 20000;
+
+exports.setup = function(t){
+  t.timeoutAfter(instrumentalLatency*2.2); // needs to be more than Instrumental latency, a little more than the timeout below
+
+  // Setup something to stop the checkForMetric loop so node exits.
+  timer = setTimeout(function(){
+    timedOut = true;
+  }, instrumentalLatency*2);
+  tape_test.onFinish(function(){
+    clearTimeout(timer);
+  });
+}
+
+exports.sendMetric = function(metricName, time, options){
+  if(typeof(options) === 'undefined') options = {};
+  if (!options.skipInit) {
+    dummy_events = new EventEmitter();
+    exports.instrumental.init(now, config, dummy_events)
+  };
+  metrics = {
+    counters: {},
+    counter_rates: {},
+    timer_data: {},
+    gauges: {},
+    sets: {},
+  };
+  metrics.counters[metricName] = 1;
+  dummy_events.emit("flush", time, metrics);
+}
+
+exports.checkForMetric = function(metricName, options) {
+  var httpOptions = {
+    hostname: 'instrumentalapp.com',
+    path: '/api/2/metrics/'+metricName,
+    headers: {
+      'X-Instrumental-Token': process.env.INSTRUMENTAL_TEST_TOKEN,
+    }
+  };
+  var req = https.get(httpOptions, function(res){
+    // console.warn('statusCode:', res.statusCode);
+    // console.warn('headers:', res.headers);
+    var body = '';
+    res.on('data', function(chunk) {
+      body += chunk;
+    });
+    res.on('end', function() {
+      // console.warn(body);
+      var data = JSON.parse(body).response.metrics[0].values.data;
+      var last_point = data[data.length-1];
+      var expectedSum = options.expectedSum || 1;
+      if (last_point.s == expectedSum) {
+        options.found();
+      } else {
+        if (timedOut) {
+          options.timeout();
+        } else {
+          setTimeout(function(){exports.checkForMetric(metricName, options)}, 1000);
+        }
+      }
+    });
+  });
+  req.on('error', function(e){
+    console.error(e.message);
+    options.error();
+  });
+}


### PR DESCRIPTION
Previously this was logged on each metric send which caused at least one
user an issue with their logs filling up. This info doesn't change, so we
can log it on init instead of every send.

This also fixes some test issues. More info in the relevant commits.